### PR TITLE
Add configuable username, Fix surrounding password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,21 +10,21 @@ ENV LSB_RELEASE xenial
 # Install base APT packages, prepare sudo
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install   \
-        wget vim less curl unzip git python build-essential sudo \
-        fontconfig libfontconfig1 \
-	gconf-service libasound2 libatk1.0-0 \
-	libatk-bridge2.0-0 libc6 libcairo2 \
-	libcups2 libdbus-1-3 libexpat1 \
-	libfontconfig1 libgcc1 libgconf-2-4 \
-	libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
-	libnspr4 libpango-1.0-0 libpangocairo-1.0-0 \
-	libstdc++6 libx11-6 libx11-xcb1 \
-	libxcb1 libxcomposite1 libxcursor1 \
-	libxdamage1 libxext6 libxfixes3 \
-	libxi6 libxrandr2 libxrender1 \
-	libxss1 libxtst6 ca-certificates \
-	fonts-liberation libappindicator1 libnss3 \
-	lsb-release xdg-utils wget && \
+    wget vim less curl unzip git python build-essential sudo \
+    fontconfig libfontconfig1 \
+    gconf-service libasound2 libatk1.0-0 \
+    libatk-bridge2.0-0 libc6 libcairo2 \
+    libcups2 libdbus-1-3 libexpat1 \
+    libfontconfig1 libgcc1 libgconf-2-4 \
+    libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
+    libnspr4 libpango-1.0-0 libpangocairo-1.0-0 \
+    libstdc++6 libx11-6 libx11-xcb1 \
+    libxcb1 libxcomposite1 libxcursor1 \
+    libxdamage1 libxext6 libxfixes3 \
+    libxi6 libxrandr2 libxrender1 \
+    libxss1 libxtst6 ca-certificates \
+    fonts-liberation libappindicator1 libnss3 \
+    lsb-release xdg-utils wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     groupadd -g 1000 c9 && \
     useradd  -g c9 -G sudo -u 1000 -m c9 && \
@@ -37,6 +37,7 @@ RUN cd /home/c9 && \
     /sbin/setuser c9 c9sdk/scripts/install-sdk.sh
 
 # C9 user default password
+ENV C9_USER admin
 ENV C9_PASSWORD password
 
 # Add runit configuration

--- a/files/service/c9/run
+++ b/files/service/c9/run
@@ -3,4 +3,4 @@ export PATH=/home/c9/.c9/node/bin:$PATH
 export HOME=/home/c9
 
 cd   /home/c9/c9sdk
-exec /sbin/setuser c9 node server.js -l 0.0.0.0 -p 8080 -w /home/c9 -a admin:${C9_PASSWORD}
+exec /sbin/setuser c9 node server.js -l 0.0.0.0 -p 8080 -w /home/c9 -a "${C9_USER}:${C9_PASSWORD}"


### PR DESCRIPTION
Without surrounding quote, It is malfunctioning with `C9_PASSWORD` which contains space characters.
Additionally, Add configurable `C9_USER` environment